### PR TITLE
Statsd Reporter

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,7 +25,6 @@ ext {
 		  ],
 		CASSANDRA_SPARK : "com.datastax.spark:spark-cassandra-connector_$SPARK_SCALA_VERSION:2.0.2",
 		CASSANDRA_MIGRATION : "com.contrastsecurity:cassandra-migration:0.6",
-		STATSD : 'com.readytalk:metrics3-statsd:4.1.0',
 		LOGBACK : ["ch.qos.logback:logback-core:1.1.3", "ch.qos.logback:logback-classic:1.1.3"]
 	]
 }

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/ConsoleReporter.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/ConsoleReporter.java
@@ -11,7 +11,7 @@ class ConsoleReporter extends StreamingQueryListener {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleReporter.class);
 
 	@Override
-	public void onQueryStarted(final QueryStartedEvent queryStartedEvent) {
+	public void onQueryStarted(QueryStartedEvent queryStartedEvent) {
 		LOGGER.info(
 				"Started query event [name: {}, id: {}, runId: {}].",
 				queryStartedEvent.name(),
@@ -20,12 +20,12 @@ class ConsoleReporter extends StreamingQueryListener {
 	}
 
 	@Override
-	public void onQueryProgress(final QueryProgressEvent queryProgressEvent) {
+	public void onQueryProgress(QueryProgressEvent queryProgressEvent) {
 		LOGGER.info("Query progress: {}.", queryProgressEvent);
 	}
 
 	@Override
-	public void onQueryTerminated(final QueryTerminatedEvent queryTerminatedEvent) {
+	public void onQueryTerminated(QueryTerminatedEvent queryTerminatedEvent) {
 		LOGGER.info("Query terminated: [id: {}, runId: {}]", queryTerminatedEvent.id(), queryTerminatedEvent.runId());
 
 		if (queryTerminatedEvent.exception().isDefined()) {

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/RemoteStatsD.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/RemoteStatsD.java
@@ -1,0 +1,104 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Example usage:
+ * <p>
+ * StatsD client = new StatsD("statsd.example.com", 8125, 512);
+ * // increment by 1
+ * client.increment("foo.bar.baz");
+ * // increment by 10
+ * client.increment("foo.bar.baz", 10);
+ * // sample rate
+ * client.increment("foo.bar.baz", 10, .1);
+ * // increment multiple keys by 1
+ * client.increment("foo.bar.baz", "foo.bar.boo", "foo.baz.bar");
+ * // increment multiple keys by 10 -- yeah, it's "backwards"
+ * client.increment(10, "foo.bar.baz", "foo.bar.boo", "foo.baz.bar");
+ * // multiple keys with a sample rate
+ * client.increment(10, .1, "foo.bar.baz", "foo.bar.boo", "foo.baz.bar");
+ * // Timers in milliseconds
+ * client.timing("foo.bar", 123);
+ * // Gauges
+ * client.gauge("foo.bar", 5)
+ */
+class RemoteStatsD implements StatsD {
+
+	private static Logger LOGGER = LoggerFactory.getLogger(RemoteStatsD.class);
+
+	private final UDPSender sender;
+	private final int bufferSize;
+	private final String prefix;
+	private final StringBuilder buffer;
+
+	RemoteStatsD(UDPSender sender, int bufferSize, String prefix) {
+		this.sender = sender;
+		this.bufferSize = bufferSize;
+		this.prefix = prefix;
+		this.buffer = new StringBuilder(bufferSize);
+	}
+
+	@Override
+	public void timing(String key, long value) {
+		send(String.format("%s:%d|ms", key, value));
+	}
+
+	@Override
+	public void increment(String key) {
+		send(String.format("%s:%s|c", key, 1));
+	}
+
+	@Override
+	public void increment(String key, int magnitude) {
+		send(String.format("%s:%s|c", key, magnitude));
+	}
+
+	@Override
+	public void sets(String key, long value) {
+		send(String.format("%s:%s|s", key, value));
+	}
+
+	@Override
+	public void gauges(String key, long value) {
+		send(String.format("%s:%s|g", key, value));
+	}
+
+	@Override
+	public void flush() {
+		doFlush();
+	}
+
+	private void send(String stat) {
+		stat = prefix + stat;
+
+		if (stat.length() > bufferSize) {
+			LOGGER.error("Metric size [{}] higher than buffer size [{}], discarding!", stat.length(), bufferSize);
+			return;
+		}
+
+		if (buffer.length() + stat.length() > bufferSize) {
+			doFlush();
+		}
+
+		buffer.append(stat).append("\n");
+	}
+
+	private void doFlush() {
+		String stat;
+
+		synchronized (buffer) {
+			if (buffer.length() == 0) {
+				return;
+			}
+
+			stat = buffer.toString();
+			// clear buffer
+			buffer.setLength(0);
+		}
+
+		LOGGER.debug("Sending stats:{}", stat);
+		sender.send(stat);
+	}
+}

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsD.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsD.java
@@ -1,0 +1,16 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+public interface StatsD {
+
+	void timing(String key, long value);
+
+	void increment(String key);
+
+	void increment(String key, int magnitude);
+
+	void sets(String key, long value);
+
+	void gauges(String key, long value);
+
+	void flush();
+}

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDConfiguration.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDConfiguration.java
@@ -1,0 +1,43 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import com.netflix.governator.annotations.Configuration;
+import org.hibernate.validator.constraints.NotBlank;
+
+import java.io.Serializable;
+
+class StatsDConfiguration implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@NotBlank
+	@Configuration("nightfall.statsd.prefix")
+	private String prefix;
+	@NotBlank
+	@Configuration("nightfall.statsd.host")
+	private String host;
+	@Configuration("nightfall.statsd.port")
+	private int port = 8125;
+	@Configuration("nightfall.statsd.bufferSize")
+	private int bufferSize = 512;
+
+	public String getPrefix() {
+		if (!prefix.endsWith(".")) {
+			prefix = prefix + ".";
+		}
+
+		return prefix;
+
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public int getBufferSize() {
+		return bufferSize;
+	}
+}

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDModule.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDModule.java
@@ -1,0 +1,30 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import com.elo7.nightfall.di.ModuleProvider;
+import com.elo7.nightfall.di.NightfallConfigurations;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import org.apache.commons.lang3.BooleanUtils;
+
+@ModuleProvider
+public class StatsDModule extends AbstractModule {
+
+	private final NightfallConfigurations configuration;
+
+	@Inject
+	StatsDModule(final NightfallConfigurations configuration) {
+		this.configuration = configuration;
+	}
+
+	@Override
+	protected void configure() {
+		Boolean isStatsDEnabled = configuration
+				.getProperty("com.elo7.nightfall.di.providers.reporter.statsd.StatsDReporter")
+				.map(BooleanUtils::toBoolean)
+				.orElse(false);
+
+		if (isStatsDEnabled) {
+			bind(StatsD.class).toProvider(StatsDProvider.class);
+		}
+	}
+}

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDProvider.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDProvider.java
@@ -1,0 +1,29 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+import java.io.IOException;
+
+class StatsDProvider implements Provider<StatsD> {
+
+	private final StatsDConfiguration configuration;
+
+	@Inject
+	StatsDProvider(final StatsDConfiguration configuration) {
+		this.configuration = configuration;
+	}
+
+	@Override
+	public StatsD get() {
+		try {
+			return new RemoteStatsD(new UDPSender(
+					configuration.getHost(),
+					configuration.getPort()),
+					configuration.getBufferSize(),
+					configuration.getPrefix());
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to create StatsD client", e);
+		}
+	}
+}

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDReporter.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDReporter.java
@@ -1,0 +1,45 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import com.elo7.nightfall.di.Component;
+import com.google.inject.Inject;
+import org.apache.spark.sql.streaming.StreamingQueryListener;
+import org.apache.spark.sql.streaming.StreamingQueryProgress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+@Component
+class StatsDReporter extends StreamingQueryListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StatsDReporter.class);
+
+	private final StatsD statsD;
+
+	@Inject
+	StatsDReporter(StatsD statsD) throws IOException {
+		this.statsD = statsD;
+	}
+
+	@Override
+	public void onQueryStarted(QueryStartedEvent event) {
+		LOGGER.debug("Query Started, nothing to report");
+	}
+
+	@Override
+	public void onQueryProgress(QueryProgressEvent event) {
+		StreamingQueryProgress progress = event.progress();
+
+		progress.durationMs().forEach((key, duration) -> statsD.timing("duration." + key, duration));
+		statsD.gauges("inputRowsPerSecond", Math.round(progress.inputRowsPerSecond()));
+		statsD.gauges("processedRowsPerSecond", Math.round(progress.processedRowsPerSecond()));
+		statsD.gauges("numInputRows", progress.numInputRows());
+		// Ensure all data was sent
+		statsD.flush();
+	}
+
+	@Override
+	public void onQueryTerminated(QueryTerminatedEvent event) {
+		LOGGER.debug("Query terminated, nothing to report");
+	}
+}

--- a/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/UDPSender.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/reporter/statsd/UDPSender.java
@@ -1,0 +1,50 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+
+class UDPSender {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(UDPSender.class);
+	private static String CHAR_SET = "utf-8";
+
+	private final InetSocketAddress address;
+	private DatagramChannel channel;
+
+	UDPSender(String host, int port) throws IOException {
+		address = new InetSocketAddress(InetAddress.getByName(host), port);
+		channel = DatagramChannel.open();
+	}
+
+	void send(String stat) {
+		try {
+			final byte[] data = stat.getBytes(CHAR_SET);
+			if (channel.isOpen()) {
+				final int nbSentBytes = channel.send(ByteBuffer.wrap(data), address);
+
+				if (data.length != nbSentBytes) {
+					LOGGER.error(
+							"Could not send entirely stat {} to host {}:{}. Only sent {} bytes out of {} bytes",
+							stat, address.getHostName(), address.getPort(), nbSentBytes, data.length);
+				}
+			} else {
+				LOGGER.error("StatsD socket is closed! Dropped metrics: {}", stat);
+				channel = DatagramChannel.open();
+				LOGGER.debug("Channel re-opened");
+			}
+		} catch (UnsupportedEncodingException e) {
+			LOGGER.error("Error generating StatsD Payload. Couldn't generate byte array", e);
+		} catch (IOException e) {
+			LOGGER.error(
+					"Could not send stat {} to host {}:{}",
+					stat, address.getHostName(), address.getPort(), e);
+		}
+	}
+}

--- a/di/src/test/java/com/elo7/nightfall/di/providers/reporter/statsd/RemoteStatsDTest.java
+++ b/di/src/test/java/com/elo7/nightfall/di/providers/reporter/statsd/RemoteStatsDTest.java
@@ -1,0 +1,112 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteStatsDTest {
+
+	private RemoteStatsD subject;
+	@Mock
+	private UDPSender sender;
+	private final String PREFIX = "remoteStatsD.";
+
+	@Before
+	public void setup() {
+		subject = new RemoteStatsD(sender, 50, PREFIX);
+	}
+
+	@Test
+	public void shouldNotSentWhenBufferIsNotFull() {
+		subject.gauges("stat", 1);
+
+		verify(sender, never()).send(anyString());
+	}
+
+	@Test
+	public void shouldSentWhenBufferIsFull() {
+		subject.gauges("sta.that.will.let.the.buffer.full", 1);
+		subject.gauges("another.one", 1);
+
+		verify(sender).send(anyString());
+	}
+
+	@Test
+	public void shouldNotFlushWhenBufferIsEmpty() {
+		subject.flush();
+
+		verify(sender, never()).send(anyString());
+	}
+
+	@Test
+	public void shouldFlushWhenBufferIsNotEmpty() {
+		subject.gauges("stat", 1);
+		subject.flush();
+
+		verify(sender).send(anyString());
+	}
+
+	@Test
+	public void shouldDiscardStatsHigherThanBufferSize() {
+		subject.gauges("a.very.big.stat.that.is.higher.than.buffer.size.or.at.least.we.hope.so", 1);
+		subject.flush();
+
+		verify(sender, never()).send(anyString());
+	}
+
+	@Test
+	public void shouldFormatTimingCorrectly() {
+		subject.timing("timer", 2);
+		subject.flush();
+
+		verify(sender).send(PREFIX + "timer:2|ms\n");
+	}
+
+	@Test
+	public void shouldFormatIncrementCorrectly() {
+		subject.increment("inc");
+		subject.flush();
+
+		verify(sender).send(PREFIX + "inc:1|c\n");
+	}
+
+	@Test
+	public void shouldFormatIncrementWithMagnitudeCorrectly() {
+		subject.increment("inc", 2);
+		subject.flush();
+
+		verify(sender).send(PREFIX + "inc:2|c\n");
+	}
+
+	@Test
+	public void shouldFormatSetsCorrectly() {
+		subject.sets("sets", 4);
+		subject.flush();
+
+		verify(sender).send(PREFIX + "sets:4|s\n");
+	}
+
+	@Test
+	public void shouldFormatGaugesCorrectly() {
+		subject.gauges("gauge", 5);
+		subject.flush();
+
+		verify(sender).send(PREFIX + "gauge:5|g\n");
+	}
+
+	@Test
+	public void shouldFormatMultiplesMetricsCorrectly() {
+		subject.increment("inc1");
+		subject.increment("inc2");
+		subject.flush();
+
+		verify(sender).send(PREFIX + "inc1:1|c\n" + PREFIX + "inc2:1|c\n");
+	}
+}

--- a/di/src/test/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDReporterTest.java
+++ b/di/src/test/java/com/elo7/nightfall/di/providers/reporter/statsd/StatsDReporterTest.java
@@ -1,0 +1,66 @@
+package com.elo7.nightfall.di.providers.reporter.statsd;
+
+import org.apache.spark.sql.streaming.StreamingQueryListener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StatsDReporterTest {
+
+	@InjectMocks
+	private StatsDReporter subject;
+	@Mock
+	private StatsD statsD;
+	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	private StreamingQueryListener.QueryProgressEvent event;
+
+	@Test
+	public void shouldSendMetricForInputRowsPerSecondOnQueryProgress() {
+		double rows = 1.1;
+		when(event.progress().inputRowsPerSecond()).thenReturn(rows);
+		subject.onQueryProgress(event);
+
+		verify(statsD).gauges("inputRowsPerSecond", 1L);
+	}
+
+	@Test
+	public void shouldSendMetricForProcessedRowsPerSecondOnQueryProgress() {
+		double rows = 1.1;
+		when(event.progress().processedRowsPerSecond()).thenReturn(rows);
+		subject.onQueryProgress(event);
+
+		verify(statsD).gauges("processedRowsPerSecond", 1L);
+	}
+
+	@Test
+	public void shouldSendMetricForNumInputRowsOnQueryProgress() {
+		when(event.progress().numInputRows()).thenReturn(1L);
+		subject.onQueryProgress(event);
+
+		verify(statsD).gauges("numInputRows", 1L);
+	}
+
+	@Test
+	public void shouldSendMetricForAllDurationsOnQueryProgress() {
+		Map<String, Long> durations = new HashMap<>();
+
+		durations.put("first", 1L);
+		durations.put("second", 2L);
+
+		when(event.progress().durationMs()).thenReturn(durations);
+		subject.onQueryProgress(event);
+
+		verify(statsD).timing("duration.first", 1L);
+		verify(statsD).timing("duration.second", 2L);
+	}
+}

--- a/riposte/build.gradle
+++ b/riposte/build.gradle
@@ -12,6 +12,6 @@ apply from: "$rootDir/shadow-jar.gradle"
 
 dependencies {
 	compile  project(':di')
-	provided libs.SPARK, libs.COMMONS_CLI, libs.AWS
+	provided libs.SPARK, libs.COMMONS_CLI, libs.AWS, libs.KAFKA_0_10
 	testCompile libs.TEST
 }

--- a/riposte/src/main/resources/nightfall.properties.sample
+++ b/riposte/src/main/resources/nightfall.properties.sample
@@ -14,3 +14,8 @@ nightfall.riposte.writer.format=console
 
 # Operations
 nightfall.riposte.sql=SELECT type, COUNT(*) AS count FROM dataSet WHERE active = 1 GROUP BY type
+
+# StatsD Reporter
+com.elo7.nightfall.di.providers.reporter.statsd.StatsDReporter=true
+nightfall.statsd.prefix=spark
+nightfall.statsd.host=localhost


### PR DESCRIPTION
🔨  @gmcoringa

## Changelog

- Adds StatsD Reporter for structure streaming
- Wiki already has this reporter documented

## Testing

- Enable StatsD:
```properties
com.elo7.nightfall.di.providers.reporter.statsd.StatsDReporter=true
nightfall.statsd.prefix=spark
nightfall.statsd.host=localhost
```

- Consume some data from Kafka using Riposte Stream for example:
- [x] Verify if the metrics were sent to StatsD: netcat for MacOS: ``nc -u -l 8125``
