### PR TITLE
Upgrade spark to 2.4.3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // Dependencies
 ext {
-	SPARK_VERSION = "2.4.0"
+	SPARK_VERSION = "2.4.3"
 	SPARK_SCALA_VERSION = "2.11"
 
 	libs = [

--- a/di/src/main/java/com/elo7/nightfall/di/providers/SparkSessionProvider.java
+++ b/di/src/main/java/com/elo7/nightfall/di/providers/SparkSessionProvider.java
@@ -28,6 +28,10 @@ class SparkSessionProvider implements Provider<SparkSession> {
 				.getPropertiesWithPrefix("spark.")
 				.forEach(builder::config);
 
+		configurations
+				.getPropertiesWithPrefix("hive.")
+				.forEach(builder::config);
+
 		boolean enableHive = configurations.getProperty("nightfall.spark.hive.enable").map(BooleanUtils::toBoolean).orElse(false);
 
 		if (enableHive) {


### PR DESCRIPTION
## Changelog

- Upgrades spark to 2.4.3
- Auto configure all properties with prefix `hive.` in spark session
